### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Algorithm.md
+++ b/Algorithm.md
@@ -1,4 +1,4 @@
-##Algorithm
+## Algorithm
 
 1. algorithms  
 module of algorithms for Python.   

--- a/Audio.md
+++ b/Audio.md
@@ -1,4 +1,4 @@
-##Audio
+## Audio
 
 
 1. beets  

--- a/Authentication.md
+++ b/Authentication.md
@@ -1,4 +1,4 @@
-#Authentication
+# Authentication
 
 1. django-allauth  
 Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party account authentication.  

--- a/BigDataandCloud.md
+++ b/BigDataandCloud.md
@@ -1,4 +1,4 @@
-##Big Data and Cloud 
+## Big Data and Cloud 
 
 1. aws-cli  
 Universal Command Line Interface for Amazon Web Services  

--- a/Book.md
+++ b/Book.md
@@ -1,4 +1,4 @@
-##Book
+## Book
 
 1. BuildingMachineLearningSystemsWithPython  
 Source Code for the book Machine Learning Systems with Python   

--- a/Chat.md
+++ b/Chat.md
@@ -1,4 +1,4 @@
-##Chat
+## Chat
 
 1. quietnet  
 Simple chat program using near ultrasonic frequencies. Works without Wifi or Bluetooth and won't show up in a pcap.  

--- a/CommandLineTools.md
+++ b/CommandLineTools.md
@@ -1,4 +1,4 @@
-##Command Line Tools
+## Command Line Tools
 
 1. docopt  
 Pythonic command line arguments parser, that will make you smile.  

--- a/Concurrency.md
+++ b/Concurrency.md
@@ -1,4 +1,4 @@
-##Concurrency
+## Concurrency
 
 
 1. pulsar   

--- a/ContentManagementSystem.md
+++ b/ContentManagementSystem.md
@@ -1,4 +1,4 @@
-##Content Management System  
+## Content Management System  
 
 1. ckan  
 CKAN is an open-source DMS (data management system) for powering data hubs and data portals.  

--- a/Cool Application.md
+++ b/Cool Application.md
@@ -1,4 +1,4 @@
-##Cool Application
+## Cool Application
 
 1. anki   
 Anki for desktop computers.   

--- a/DataBaseandRelatedTools.md
+++ b/DataBaseandRelatedTools.md
@@ -1,4 +1,4 @@
-##DataBase and Related Tools
+## DataBase and Related Tools
 
 1. redis-py  
 The Python interface to the Redis key-value store.  

--- a/DataProcessing.md
+++ b/DataProcessing.md
@@ -1,4 +1,4 @@
-##Data Processing  
+## Data Processing  
 
 1. pandas  
 pandas is a package providing fast, flexible, and expressive data structures designed to make working with "relational" or "labeled" data both easy and intuitive. It aims to be the fundamental high-level building block for doing practical, real world data analysis in Python.  

--- a/Debugging.md
+++ b/Debugging.md
@@ -1,4 +1,4 @@
-##Debugging
+## Debugging
 
 1. django-debug-toolbar  
 The Django Debug Toolbar is a configurable set of panels that display various debug information about the current request/response and when clicked, display more details about the panel's content.  

--- a/Devops.md
+++ b/Devops.md
@@ -1,4 +1,4 @@
-##Devops  
+## Devops  
 
 1. ansible  
 Ansible is a radically simple configuration-management, application deployment, task-execution, and multinode orchestration engine.  

--- a/EditorandEditorEnhancements.md
+++ b/EditorandEditorEnhancements.md
@@ -1,4 +1,4 @@
-##Editor and Editor Enhancements 
+## Editor and Editor Enhancements 
 
 1. GitGutter  
 A sublime text plugin to show an icon in the gutter area indicating whether a line has been inserted, modified or deleted.  

--- a/Game.md
+++ b/Game.md
@@ -1,4 +1,4 @@
-##Game
+## Game
 
 1. Minecraft  
 Simple Minecraft-inspired demo written in Python and Pyglet.  

--- a/Git.md
+++ b/Git.md
@@ -1,4 +1,4 @@
-##Git 
+## Git 
 
 1. legit  
 Legit is a complementary command-line interface for Git, optimized for workflow simplicity.  

--- a/Icon.md
+++ b/Icon.md
@@ -1,4 +1,4 @@
-##Icon 
+## Icon 
 
 1. Iconic  
 A minimal set of icons in raster, vector and font formats  

--- a/Image.md
+++ b/Image.md
@@ -1,4 +1,4 @@
-##Image
+## Image
 
 1. Pillow  
 Python Imaging Library.  

--- a/JobScheduler.md
+++ b/JobScheduler.md
@@ -1,4 +1,4 @@
-##Job Scheduler
+## Job Scheduler
 
 1. rq  
 RQ is a simple Python library for queueing jobs and processing them in the background with workers. It is backed by Redis and it is designed to have a low barrier to entry.  

--- a/Mail.md
+++ b/Mail.md
@@ -1,4 +1,4 @@
-##Mail  
+## Mail  
 
 1. Mailpile  
 Mailpile is a modern, fast web-mail client with user-friendly encryption and privacy features.  

--- a/Network.md
+++ b/Network.md
@@ -1,4 +1,4 @@
-##Network and Related Tools
+## Network and Related Tools
 
 1. requests  
 Requests allow you to send HTTP/1.1 requests. You can add headers, form data, multipart files, and parameters with simple Python dictionaries, and access the response data in the same way.  

--- a/Other.md
+++ b/Other.md
@@ -1,4 +1,4 @@
-##Other
+## Other
 
 1. python-patterns  
 A collection of design patterns and idioms in Python.  

--- a/PackageManager.md
+++ b/PackageManager.md
@@ -1,4 +1,4 @@
-##Package Manager 
+## Package Manager 
 
 1. pip  
 A tool for installing Python packages.  

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ send me a pull request and follow the [contribution guide](https://github.com/ch
 * [Web Mining](https://github.com/checkcheckzz/Python-open-projects/blob/master/WebMining.md)
 * [Web Site Source](https://github.com/checkcheckzz/Python-open-projects/blob/master/WebSiteSource.md)
 
-###License
+### License
 
 Python-github-projects is licensed under the [CC-By 3.0 License](http://creativecommons.org/licenses/by/3.0/).
 

--- a/Science.md
+++ b/Science.md
@@ -1,4 +1,4 @@
-##Science
+## Science
 
 1. ipython  
 IPython provides a rich architecture for interactive computing.  

--- a/StaticWebGenerator.md
+++ b/StaticWebGenerator.md
@@ -1,4 +1,4 @@
-##Static Web Generator
+## Static Web Generator
 
 1. pelican  
 Static site generator that supports Markdown and reST syntax.  

--- a/Testing.md
+++ b/Testing.md
@@ -1,4 +1,4 @@
-##Testing
+## Testing
 
 1. python_koans  
 Python Koans is a port of "Ruby Koans" it is an interactive tutorial for learning Python by practicing TDD and making tests pass.  

--- a/ToolandUtilities.md
+++ b/ToolandUtilities.md
@@ -1,4 +1,4 @@
-##Tools and Utilities  
+## Tools and Utilities  
 
 1. sh  
 sh is a full-fledged subprocess replacement for Python that allows you to call any program as if it were a function.  

--- a/ToolsWeb.md
+++ b/ToolsWeb.md
@@ -1,4 +1,4 @@
-##Tools for Web
+## Tools for Web
 
 1. huxley  
 Huxley is a test-like system for catching visual regressions in Web applications. It watches you browse, takes screenshots, and tells you when they change.  

--- a/UsefulAPI.md
+++ b/UsefulAPI.md
@@ -1,4 +1,4 @@
-##Useful API
+## Useful API
 
 1. tweepy  
 An easy-to-use Python library for accessing the Twitter API.  

--- a/Video.md
+++ b/Video.md
@@ -1,4 +1,4 @@
-##Video
+## Video
 
 1. CouchPotatoServer  
 CouchPotato is an automatic NZB and torrent downloader.  

--- a/Visualization.md
+++ b/Visualization.md
@@ -1,4 +1,4 @@
-##Visualization
+## Visualization
 
 1. matplotlib  
 matplotlib is a python 2D plotting library which produces publication quality figures in a variety of hardcopy formats and interactive environments across platforms.  

--- a/WebFrameworkandRelatedTool.md
+++ b/WebFrameworkandRelatedTool.md
@@ -1,4 +1,4 @@
-##Web Framework and Related Tools
+## Web Framework and Related Tools
 
 1. django  
 Django is a Python high-level Web framework that encourages rapid development and clean, pragmatic design.  

--- a/WebMining.md
+++ b/WebMining.md
@@ -1,4 +1,4 @@
-##Web Mining
+## Web Mining
 
 1. scrapy  
 Scrapy is a fast high-level screen scraping and web crawling framework, used to crawl websites and extract structured data from their pages. It can be used for a wide range of purposes, from data mining to monitoring and automated testing.  

--- a/WebSiteSource.md
+++ b/WebSiteSource.md
@@ -1,4 +1,4 @@
-##Web Site Source
+## Web Site Source
 
 1. reddit  
 The code that powers reddit.com.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
