### PR TITLE
docs: Fix a few typos

### DIFF
--- a/EditorandEditorEnhancements.md
+++ b/EditorandEditorEnhancements.md
@@ -24,7 +24,7 @@ DocBlockr is a package for Sublime Text which makes writing documentation a bree
 Project Source:  https://github.com/spadgos/sublime-jsdocs  
 
 1. gmate  
-Set of plugins and improvements to make Gedit a powerfull programmer text editor.  
+Set of plugins and improvements to make Gedit a powerful programmer text editor.  
 Project Source: https://github.com/gmate/gmate  
 
 1. sublimetext-markdown-preview  
@@ -108,7 +108,7 @@ Project Source: https://github.com/guillermooo/Vintageous
 Project Homepage: http://guillermooo.bitbucket.org/Vintageous/  
 
 1. Stino  
-Stino is a Sublime Text plugin, which provides an Arduino-like environement for editing, compiling and uploading sketches.   
+Stino is a Sublime Text plugin, which provides an Arduino-like environment for editing, compiling and uploading sketches.   
 Project Source: https://github.com/Robot-Will/Stino   
 
 1. editorconfig-sublime   

--- a/ToolandUtilities.md
+++ b/ToolandUtilities.md
@@ -262,7 +262,7 @@ One command to have a working virtualenv + virtualenvwrapper environment.
 Project Source: https://github.com/brainsik/virtualenv-burrito  
 
 1. maestro  
-Maestro provides the ability to easily launch, orchestrate and manage mulitple Docker containers as single unit.   
+Maestro provides the ability to easily launch, orchestrate and manage multiple Docker containers as single unit.   
 Project Source: https://github.com/toscanini/maestro     
 
 1. python-lust  

--- a/Visualization.md
+++ b/Visualization.md
@@ -11,7 +11,7 @@ Project Source: https://github.com/wrobstory/vincent
 Project Documentation: https://vincent.readthedocs.org/en/latest/
 
 1. d3py  
-A plottling library for python, based on D3.  
+A plotting library for python, based on D3.  
 Project Source: https://github.com/mikedewar/d3py  
 
 1. seaborn    


### PR DESCRIPTION
There are small typos in:
- EditorandEditorEnhancements.md
- ToolandUtilities.md
- Visualization.md

Fixes:
- Should read `powerful` rather than `powerfull`.
- Should read `plotting` rather than `plottling`.
- Should read `multiple` rather than `mulitple`.
- Should read `environment` rather than `environement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md